### PR TITLE
fix(frontend): resolve hydration mismatch between SSR and client in d…

### DIFF
--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -8,9 +8,12 @@ import { BsPatchCheckFill, BsTrophy, BsStarFill } from "react-icons/bs";
 import { OnChainStatus } from "@/components/stellar/OnChainStatus";
 
 export default function DashboardLayout({ children }: { children: ReactNode }) {
-  const { totalXP, completedModules } = useProgress();
+  const { totalXP, completedModules, isHydrated } = useProgress();
   const course = courses[0];
   const totalModules = course.modules.length;
+
+  const displayXP = isHydrated ? totalXP : 0;
+  const displayCompleted = isHydrated ? completedModules : 0;
 
   return (
     <div className="flex flex-wrap lg:justify-center gap-8 max-w-[1536px] m-auto px-4 py-6">
@@ -26,7 +29,7 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
               <BsStarFill className="text-darkOrange" size={18} />
             </div>
             <div>
-              <p className="text-2xl font-bold text-darkGreen">{totalXP}</p>
+              <p className="text-2xl font-bold text-darkGreen">{displayXP}</p>
               <p className="text-xs text-darkGrey">XP totales</p>
             </div>
           </div>
@@ -37,7 +40,7 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
             </div>
             <div>
               <p className="text-lg font-semibold text-darkGreen">
-                {completedModules}/{totalModules}
+                {displayCompleted}/{totalModules}
               </p>
               <p className="text-xs text-darkGrey">Módulos completados</p>
             </div>
@@ -47,7 +50,7 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
             <div
               className="bg-active h-2 rounded-full transition-all"
               style={{
-                width: `${totalModules > 0 ? (completedModules / totalModules) * 100 : 0}%`,
+                width: `${totalModules > 0 ? (displayCompleted / totalModules) * 100 : 0}%`,
               }}
             />
           </div>

--- a/src/components/stellar/OnChainStatus.tsx
+++ b/src/components/stellar/OnChainStatus.tsx
@@ -2,9 +2,11 @@
 
 import { useEffect } from "react";
 import { useStellarProgress } from "@/hooks/useStellarProgress";
+import { useHydrated } from "@/lib/hydration";
 import { BsLink45Deg, BsArrowRepeat } from "react-icons/bs";
 
 export function OnChainStatus() {
+  const isHydrated = useHydrated();
   const {
     connected,
     xpBalance,
@@ -20,7 +22,7 @@ export function OnChainStatus() {
     }
   }, [connected, fetchOnChainProgress]);
 
-  if (!connected) {
+  if (!isHydrated || !connected) {
     return (
       <article className="p-5 border border-borderGrey/30 rounded-2xl bg-white">
         <div className="flex items-center gap-2 mb-3">

--- a/src/hooks/useProgress.ts
+++ b/src/hooks/useProgress.ts
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
+import { useHydrated } from "@/lib/hydration";
 
 export interface ModuleProgress {
   completed: boolean;
@@ -31,7 +32,15 @@ function saveProgress(progress: CourseProgress) {
 }
 
 export function useProgress() {
-  const [progress, setProgress] = useState<CourseProgress>(loadProgress);
+  const isHydrated = useHydrated();
+  const [progress, setProgress] = useState<CourseProgress>({});
+
+  useEffect(() => {
+    if (isHydrated) {
+      const loaded = loadProgress();
+      setProgress(loaded);
+    }
+  }, [isHydrated]);
 
   const getModuleProgress = useCallback(
     (moduleId: string): ModuleProgress => {
@@ -124,5 +133,6 @@ export function useProgress() {
     isModuleUnlocked,
     totalXP,
     completedModules,
+    isHydrated,
   };
 }

--- a/src/hooks/useStellarProgress.ts
+++ b/src/hooks/useStellarProgress.ts
@@ -2,6 +2,7 @@
 
 import { useState, useCallback } from "react";
 import { useStellarWallet } from "./useStellarWallet";
+import { useHydrated } from "@/lib/hydration";
 import {
   getXPBalance,
   getHistoricalXP,
@@ -17,6 +18,7 @@ export interface OnChainStatus {
 }
 
 export function useStellarProgress() {
+  const isHydrated = useHydrated();
   const { address, connected } = useStellarWallet();
   const [status, setStatus] = useState<OnChainStatus>({
     xpBalance: BigInt(0),
@@ -75,10 +77,11 @@ export function useStellarProgress() {
 
   return {
     ...status,
-    connected,
+    connected: isHydrated ? connected : false,
     address,
     fetchOnChainProgress,
     checkChallengeCompleted,
     checkHasBadge,
+    isHydrated,
   };
 }

--- a/src/hooks/useStellarWallet.ts
+++ b/src/hooks/useStellarWallet.ts
@@ -7,11 +7,13 @@ import {
   requestAccess,
   signTransaction,
 } from "@stellar/freighter-api";
+import { useHydrated } from "@/lib/hydration";
 
 export function useStellarWallet() {
   const [address, setAddress] = useState<string | null>(null);
   const [connected, setConnected] = useState(false);
   const [loading, setLoading] = useState(false);
+  const isHydrated = useHydrated();
 
   const checkConnection = useCallback(async () => {
     try {
@@ -29,8 +31,10 @@ export function useStellarWallet() {
   }, []);
 
   useEffect(() => {
-    checkConnection();
-  }, [checkConnection]);
+    if (isHydrated) {
+      checkConnection();
+    }
+  }, [isHydrated, checkConnection]);
 
   const connect = useCallback(async () => {
     setLoading(true);
@@ -70,5 +74,6 @@ export function useStellarWallet() {
     connect,
     disconnect,
     signTransaction,
+    isHydrated,
   };
 }

--- a/src/lib/hydration.ts
+++ b/src/lib/hydration.ts
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState, useEffect, useCallback, ReactNode, createElement, Fragment } from "react";
+
+export function useHydrated() {
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  return hydrated;
+}
+
+export function ClientOnly({ children }: { children: ReactNode }) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
+  return createElement(Fragment, null, children);
+}
+
+export function useLocalStorage<T>(key: string, defaultValue: T) {
+  const isHydrated = useHydrated();
+  const [value, setValue] = useState<T>(defaultValue);
+
+  useEffect(() => {
+    if (isHydrated) {
+      try {
+        const stored = localStorage.getItem(key);
+        if (stored) {
+          setValue(JSON.parse(stored));
+        }
+      } catch {
+        setValue(defaultValue);
+      }
+    }
+  }, [key, defaultValue, isHydrated]);
+
+  const saveValue = useCallback(
+    (newValue: T | ((prev: T) => T)) => {
+      setValue((prev) => {
+        const resolved = typeof newValue === "function"
+          ? (newValue as (prev: T) => T)(prev)
+          : newValue;
+        localStorage.setItem(key, JSON.stringify(resolved));
+        return resolved;
+      });
+    },
+    [key]
+  );
+
+  return [value, saveValue] as const;
+}
+
+export function getHydratedValue<T>(isHydrated: boolean, hydratedValue: T, defaultValue: T): T {
+  return isHydrated ? hydratedValue : defaultValue;
+}


### PR DESCRIPTION

Closes #1


**What was done**
Created src/lib/hydration.ts with a centralized useHydrated() hook that ensures browser-only APIs are never called during SSR.
Applied the guard to the components that were causing the mismatch:

useProgress — localStorage now only read after client mount
useStellarWallet — Freighter connection check deferred until hydration
useStellarProgress — connected returns false during SSR
DashboardLayout — XP and progress display 0 on server, real values on client
OnChainStatus — renders static fallback until hydrated

Result: no hydration warnings in console, consistent SSR/client output, no UI regressions.

I really enjoyed working on this project The DeFi education concept with Stellar on-chain progress is genuinely exciting.

 I'd love to keep contributing if there are more issues open. 
 
Thanks for the opportunity! 🌊 