### PR TITLE
fix(quiz): remove double-counting of last correct answer in score cal…

### DIFF
--- a/src/app/dashboard/ruta_aprendizaje/components/QuizView.tsx
+++ b/src/app/dashboard/ruta_aprendizaje/components/QuizView.tsx
@@ -44,10 +44,7 @@ export default function QuizView({ module, onBack, progress }: QuizViewProps) {
       setSelectedOption(null);
       setAnswered(false);
     } else {
-      const finalCorrect =
-        correctCount +
-        (question.options[selectedOption!]?.isCorrect ? 1 : 0);
-      const finalScore = Math.round((finalCorrect / totalQuestions) * 100);
+      const finalScore = Math.round((correctCount / totalQuestions) * 100);
       progress.completeQuiz(module.id, finalScore, module.rewardXP);
       setFinished(true);
     }


### PR DESCRIPTION
…culation

correctCount is already incremented in handleAnswer before handleNext runs, so the extra addition in handleNext was counting the last correct answer twice.

Affected scenarios:
- 4/4 correct was scoring 125% instead of 100%
- 3/4 correct was scoring 100% instead of 75%
closes #13 