### PR TITLE
fix: create /dashboard/progress route with real useProgress data

### DIFF
--- a/src/app/dashboard/progress/Compite.tsx
+++ b/src/app/dashboard/progress/Compite.tsx
@@ -1,13 +1,30 @@
-import { BsTrophy } from "react-icons/bs";
+import { BsTrophy, BsCheckCircleFill } from "react-icons/bs";
 
-export function Compite() {
+interface CompiteProps {
+  completedModules: number;
+  totalModules: number;
+}
+
+export function Compite({ completedModules, totalModules }: CompiteProps) {
+  const allCompleted = completedModules >= totalModules && totalModules > 0;
+
   return (
     <article className="p-6 border-[1px] border-lightGrey rounded-2xl self-start">
-      <h4 className="text-h4 text-orangeGrey">¡Compite y demuestra tus habilidades!</h4>
+      <h4 className="text-h4 text-orangeGrey font-semibold mb-4">
+        ¡Compite y demuestra tus habilidades!
+      </h4>
       <div className="flex items-center">
-        <BsTrophy fill="#68CC58" size={40} />
+        {allCompleted ? (
+          <BsCheckCircleFill fill="#68CC58" size={40} />
+        ) : (
+          <BsTrophy fill="#68CC58" size={40} />
+        )}
         <p className="text-subP text-darkGrey ml-6">
-          Completa 3 rutas de aprendizaje para empezar a competir
+          {allCompleted
+            ? "¡Felicidades! Completaste todos los módulos. Ya podés competir y obtener tu certificado final."
+            : `Completá ${totalModules - completedModules} módulo${
+                totalModules - completedModules !== 1 ? "s" : ""
+              } más para empezar a competir.`}
         </p>
       </div>
     </article>

--- a/src/app/dashboard/progress/Progress.tsx
+++ b/src/app/dashboard/progress/Progress.tsx
@@ -1,23 +1,91 @@
-import Image from "next/image";
-import { BsPatchCheckFill } from "react-icons/bs";
+import { useProgress } from "@/hooks/useProgress";
+import { Course } from "@/data/courses";
+import { BsPatchCheckFill, BsBook, BsStarFill } from "react-icons/bs";
 
-export default function Progress() {
+interface ProgressProps {
+  progress: ReturnType<typeof useProgress>;
+  course: Course;
+}
+
+export default function Progress({ progress, course }: ProgressProps) {
+  const { totalXP, completedModules, getModuleProgress } = progress;
+  const totalModules = course.modules.length;
+
+  // Count lessons completed vs total lessons
+  const totalLessons = course.modules.reduce(
+    (sum, m) => sum + m.lessons.length,
+    0
+  );
+  const completedLessons = course.modules.reduce((sum, m) => {
+    const modProgress = getModuleProgress(m.id);
+    return sum + modProgress.lessonsCompleted.length;
+  }, 0);
+
+  // Max possible XP for this course
+  const maxXP = course.modules.reduce((sum, m) => sum + m.rewardXP, 0);
+
+  // Progress percentage based on completed modules vs total
+  const modulePercent =
+    totalModules > 0
+      ? Math.round((completedModules / totalModules) * 100)
+      : 0;
+
   return (
     <article className="p-6 border-[1px] border-lightGrey rounded-2xl self-start mb-10">
-      <h4 className="text-darkGrey mb-4 font-semibold">Tu progreso</h4>
-      <div className="flex">
-        <BsPatchCheckFill fill="darkOrange" size={35} />
-        <div className="pl-2">
-          <span className="text-active">Objetivo diario</span>
-          <div className="flex items-center">
-            <div className="w-[150px] mr-2 bg-progressGrey rounded-full h-2.5">
-              <div className="bg-lightOrange h-2.5 rounded-full" style={{ width: "45%" }} />
-            </div>
-            <span className="text-subP text-light text-lightGrey">8/20 Puntos</span>
-          </div>
+      <h4 className="text-darkGrey mb-4 font-semibold">Tu progreso general</h4>
+
+      {/* XP earned */}
+      <div className="flex items-center gap-4 mb-4">
+        <div className="w-10 h-10 bg-darkOrange/10 rounded-xl flex items-center justify-center">
+          <BsStarFill className="text-darkOrange" size={18} />
+        </div>
+        <div>
+          <p className="text-sm text-darkGrey">XP acumulado</p>
+          <p className="text-lg font-bold text-darkGreen">
+            {totalXP} / {maxXP} XP
+          </p>
         </div>
       </div>
-      <Image src="/progressChart.svg" alt="Progress Chart" width={300} height={300} />
+
+      {/* Modules completed */}
+      <div className="flex items-center gap-4 mb-4">
+        <div className="w-10 h-10 bg-active/10 rounded-xl flex items-center justify-center">
+          <BsPatchCheckFill className="text-active" size={18} />
+        </div>
+        <div>
+          <p className="text-sm text-darkGrey">Módulos completados</p>
+          <p className="text-lg font-bold text-darkGreen">
+            {completedModules} / {totalModules}
+          </p>
+        </div>
+      </div>
+
+      {/* Lessons completed */}
+      <div className="flex items-center gap-4 mb-4">
+        <div className="w-10 h-10 bg-pink/10 rounded-xl flex items-center justify-center">
+          <BsBook className="text-pink" size={18} />
+        </div>
+        <div>
+          <p className="text-sm text-darkGrey">Lecciones completadas</p>
+          <p className="text-lg font-bold text-darkGreen">
+            {completedLessons} / {totalLessons}
+          </p>
+        </div>
+      </div>
+
+      {/* Overall progress bar */}
+      <div className="mb-2">
+        <div className="flex justify-between text-xs text-darkGrey mb-1">
+          <span>Progreso del curso</span>
+          <span>{modulePercent}%</span>
+        </div>
+        <div className="w-full bg-progressGrey rounded-full h-2.5">
+          <div
+            className="bg-active h-2.5 rounded-full transition-all"
+            style={{ width: `${modulePercent}%` }}
+          />
+        </div>
+      </div>
     </article>
   );
 }

--- a/src/app/dashboard/progress/page.tsx
+++ b/src/app/dashboard/progress/page.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import DashboardLayout from "@/components/DashboardLayout";
+import { useProgress } from "@/hooks/useProgress";
+import { courses } from "@/data/courses";
+import Progress from "./Progress";
+import { Compite } from "./Compite";
+
+export default function ProgressPage() {
+  const progress = useProgress();
+  const course = courses[0];
+
+  return (
+    <DashboardLayout>
+      <h2 className="text-2xl font-bold text-darkOrange mb-6">Tu progreso</h2>
+      <Progress progress={progress} course={course} />
+      <Compite
+        completedModules={progress.completedModules}
+        totalModules={course.modules.length}
+      />
+    </DashboardLayout>
+  );
+}

--- a/src/components/asideMenu/AsideMenu.tsx
+++ b/src/components/asideMenu/AsideMenu.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import AsideMenuBtn from "./AsideMenuBtn";
-import { BsAward, BsBook, BsJournals, BsSearch, BsStars } from "react-icons/bs";
+import { BsAward, BsBook, BsJournals, BsSearch, BsStars, BsBarChartFill } from "react-icons/bs";
 
 export default function AsideMenu() {
   return (
     <aside className="w-[100%] md:w-auto">
       <AsideMenuBtn value="Ruta de aprendizaje" icon={BsBook} fill="darkOrange" href="/dashboard" />
+      <AsideMenuBtn value="Progreso" icon={BsBarChartFill} fill="#E97D1A" href="/dashboard/progress" />
       <AsideMenuBtn value="Mis logros" icon={BsAward} fill="#68CC58" href="/dashboard/logros" />
       <AsideMenuBtn value="Ver otros cursos" icon={BsJournals} fill="#68CC58" href="#" />
       <AsideMenuBtn value="Staking" icon={BsStars} fill="#CDCDCD" href="#" />


### PR DESCRIPTION
- Create page.tsx for /dashboard/progress to resolve 404

- Update Progress.tsx to display real XP, modules, and lessons from useProgress

- Update Compite.tsx to show dynamic module completion state

- Add Progreso sidebar link to AsideMenu pointing to /dashboard/progress
closes #19 