### PR TITLE
fix: "Previous" button in LessonView navigates backward instead of forward

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -154,6 +154,9 @@ export default function Dashboard() {
           module={mod}
           lessonIndex={view.lessonIndex}
           onBack={() => goToCourse(view.courseId)}
+          onPrevious={() =>
+            setView({ ...view, lessonIndex: view.lessonIndex - 1 })
+          }
           onNext={(nextIndex) => {
             if (nextIndex < mod.lessons.length) {
               progressHook.completeLesson(

--- a/src/app/dashboard/ruta_aprendizaje/components/LessonView.tsx
+++ b/src/app/dashboard/ruta_aprendizaje/components/LessonView.tsx
@@ -9,6 +9,7 @@ interface LessonViewProps {
   lessonIndex: number;
   onBack: () => void;
   onNext: (nextIndex: number) => void;
+  onPrevious: () => void;
   progress: ReturnType<typeof useProgress>;
 }
 
@@ -17,6 +18,7 @@ export default function LessonView({
   lessonIndex,
   onBack,
   onNext,
+  onPrevious,
 }: LessonViewProps) {
   const lesson = module.lessons[lessonIndex];
   const isLast = lessonIndex === module.lessons.length - 1;
@@ -119,13 +121,7 @@ export default function LessonView({
       {/* Navigation */}
       <div className="flex justify-between items-center">
         <button
-          onClick={() => {
-            if (lessonIndex > 0) {
-              onNext(lessonIndex); // hack: we go back by re-setting
-            } else {
-              onBack();
-            }
-          }}
+          onClick={onPrevious}
           disabled={lessonIndex === 0}
           className="flex items-center gap-2 px-6 py-3 rounded-xl text-darkGrey hover:text-darkOrange disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
         >


### PR DESCRIPTION
closes #14

## Summary

The "Anterior" (Previous) button in `LessonView` advanced the user instead of going back. Its `onClick` called `onNext(lessonIndex)`, which (in the dashboard handler) marks the current lesson complete and re-sets the view index — so the button never returned the user to the previous lesson.

This PR adds a dedicated `onPrevious` handler that navigates to the previous lesson by decrementing the lesson index, without marking the current lesson as complete.

## Changes

- `src/app/dashboard/ruta_aprendizaje/components/LessonView.tsx`
  - Added an `onPrevious: () => void` prop.
  - The "Anterior" button now calls `onPrevious` directly (removed the `onNext(lessonIndex)` hack).
- `src/app/dashboard/page.tsx`
  - Wired `onPrevious` to set the view to `lessonIndex - 1`.

## Why a dedicated handler instead of `onBack()`

`onBack()` returns to the module list (it's the breadcrumb action), so it would not move the user to the previous lesson as the acceptance criteria require. Reusing `onNext` was also unsuitable because the dashboard's `onNext` marks the current lesson complete before changing the index — going backward should not complete a lesson. A separate `onPrevious` keeps backward navigation side-effect free and matches the existing `onBack`/`onNext` prop pattern.

## Acceptance criteria

- [x] "Anterior" button on lesson 2 navigates to lesson 1
- [x] "Anterior" button on lesson 3 navigates to lesson 2
- [x] "Anterior" button is disabled on lesson 1
- [x] "Siguiente" (Next) button still works correctly

## Verification

- `npm run lint` — passes (only pre-existing unrelated warnings)
- `npx tsc --noEmit` — passes
